### PR TITLE
Do not add another semicolon as it was added already. Fixes #21

### DIFF
--- a/vscode-extension/src/features/NextObjectIdCompletionItem.ts
+++ b/vscode-extension/src/features/NextObjectIdCompletionItem.ts
@@ -37,7 +37,7 @@ export class NextObjectIdCompletionItem extends CompletionItem {
                 output.log(`Another user has consumed ${type} ${objectId.id} in the meantime. Retrieved new: ${type} ${realId.id}`);
 
                 let replace = new WorkspaceEdit();
-                replace.set(uri, [TextEdit.replace(new Range(position, position.translate(0, objectId.id.toString().length)), `${realId.id}${this._injectSemicolon ? ";" : ""}`)]);
+                replace.set(uri, [TextEdit.replace(new Range(position, position.translate(0, objectId.id.toString().length)), `${realId.id}`)]);
                 workspace.applyEdit(replace);
             }]
         };


### PR DESCRIPTION
As described in #21, I think it's safe to remove the semicolon. as it is already inserted in line 23 
```typescript
this.insertText = `${objectId.id}${this._injectSemicolon ? ";" : ""}`;
```