### PR TITLE
Public reservation API

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "vjeko-al-objid",
-    "version": "2.9.1",
+    "version": "2.9.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vjeko-al-objid",
-            "version": "2.9.1",
+            "version": "2.9.3",
             "license": "MIT",
             "dependencies": {
                 "@vjeko.com/al-parser-ninja": "^1.0.8",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
     "displayName": "AL Object ID Ninja",
     "description": "Manage object IDs in multi-user environments with mind-boggling simplicity.",
     "publisher": "vjeko",
-    "version": "2.9.2",
+    "version": "2.9.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/vjekob/al-objid.git"

--- a/vscode-extension/src/api/ExtensionApi.ts
+++ b/vscode-extension/src/api/ExtensionApi.ts
@@ -1,0 +1,64 @@
+import { Uri } from "vscode";
+import { showNotificationsIfNecessary } from "../features/NextObjectIdCompletionProvider";
+import { WorkspaceManager } from "../features/WorkspaceManager";
+import { Backend } from "../lib/backend/Backend";
+import { Telemetry } from "../lib/Telemetry";
+import { NextObjectIdInfo } from "../lib/types/NextObjectIdInfo";
+
+export class ExtensionApi {
+
+    async suggestIds(uri: Uri, type: string) : Promise<number[]|undefined> {
+        const app = WorkspaceManager.instance.getALAppFromUri(uri);
+        if (!app) {
+            return undefined;
+        }
+
+        const objectId = await Backend.getNextNo(app, type, app.manifest.idRanges, false);
+        Telemetry.instance.logNextNo(app, type, false);
+
+        if (showNotificationsIfNecessary(app, objectId) || !objectId)
+            return undefined;
+
+        if (!objectId)
+            return undefined;        
+
+        if (Array.isArray(objectId.id))
+            return objectId.id as number[];
+            
+        return [objectId.id as number];
+    }
+
+    async reserveId(uri: Uri, type: string, objectId: number): Promise<number> {
+        const app = WorkspaceManager.instance.getALAppFromUri(uri);
+        if (!app)
+            return objectId;
+
+        const realId = await Backend.getNextNo(app, type, app.manifest.idRanges, true, objectId as number);
+        let changed = false;
+
+        if (realId) {
+            const realIdVal = this.getSingleId(realId);
+            changed = (realIdVal !== 0) && (realIdVal !== objectId);
+            if (changed)
+                objectId = realIdVal;
+        }
+        Telemetry.instance.logNextNo(app, type, true, changed);
+
+        return objectId;
+    }
+
+    private getSingleId(info: NextObjectIdInfo): number {
+        if (!info.id) 
+            return 0;
+
+            if (!Array.isArray(info.id))
+            return info.id as number;
+
+            let ids = info.id as number[];
+        if (ids.length === 1)
+            return ids[0];
+
+        return 0;
+    }
+
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,6 +18,7 @@ import { ConsumptionWarnings } from "./features/ConsumptionWarnings";
 import { RangeExplorerView } from "./features/treeView/rangeExplorer/RangeExplorerView";
 import { AppPoolExplorerView } from "./features/treeView/appPoolExplorer/AppPoolExplorerView";
 import { setFlags } from "./flags";
+import { ExtensionApi } from "./api/ExtensionApi";
 
 export function activate(context: ExtensionContext) {
     setFlags();
@@ -52,6 +53,9 @@ export function activate(context: ExtensionContext) {
     );
 
     ReleaseNotesHandler.instance.check(context);
+
+    // Return public extension API
+    return new ExtensionApi();
 }
 
 export function deactivate() {

--- a/vscode-extension/src/features/NextObjectIdCompletionProvider.ts
+++ b/vscode-extension/src/features/NextObjectIdCompletionProvider.ts
@@ -180,7 +180,7 @@ async function getTypeAtPosition(
     return Object.values<string>(ALObjectType).includes(type) || isTableOrEnum(type) ? type : null;
 }
 
-function showNotificationsIfNecessary(app: ALApp, objectId?: NextObjectIdInfo): boolean {
+export function showNotificationsIfNecessary(app: ALApp, objectId?: NextObjectIdInfo): boolean {
     if (!objectId) return true;
 
     if (!objectId.hasConsumption) {


### PR DESCRIPTION
A new public api class that can be used by other VS Code extensions to get IDs suggestions and to reserve them. There are 2 methods in the api
- `suggestIds` to get list of suggested IDs (1 for each ID range) without reserving them
- `reserverId` to reserve a single ID

``` javascript
let idNinjaExtension = vscode.extensions.getExtension("vjeko.vjeko-al-objid");
if ((idNinjaExtension) && (idNinjaExtension.isActive)) {
    let api = idNinjaExtension.exports;
    let ids = await api.suggestIds(uri, type);
}
```
