### PR TITLE
feat: Refactor HTTP authorization handling

### DIFF
--- a/backend/src/functions/v3/authorizeApp/index.ts
+++ b/backend/src/functions/v3/authorizeApp/index.ts
@@ -145,7 +145,6 @@ withPermissionCheck(del);
 export const authorizeApp = createEndpoint({
     moniker: "v3-authorizeApp",
     route: "v3/authorizeApp/{appId}",
-    authLevel: "anonymous",
     GET: get,
     POST: post,
     DELETE: del,

--- a/backend/src/functions/v3/autoSyncIds/index.ts
+++ b/backend/src/functions/v3/autoSyncIds/index.ts
@@ -65,7 +65,6 @@ validate(patch, array({
 export const autoSyncIds = createEndpoint({
     moniker: "v3-autoSyncIds",
     route: "v3/autoSyncIds",
-    authLevel: "anonymous",
     POST: post,
     PATCH: patch,
 });

--- a/backend/src/functions/v3/check/index.ts
+++ b/backend/src/functions/v3/check/index.ts
@@ -117,7 +117,6 @@ validate(post, arrayOrEntity({
 export const check = createEndpoint({
     moniker: "v3-check",
     route: "v3/check",
-    authLevel: "anonymous",
     POST: post,
 });
 

--- a/backend/src/functions/v3/checkApp/index.ts
+++ b/backend/src/functions/v3/checkApp/index.ts
@@ -20,6 +20,5 @@ const get: AzureHttpHandler<void, string> = async (req) => {
 export const checkApp = createEndpoint({
     moniker: "v3-checkApp",
     route: "v3/checkApp/{appId}",
-    authLevel: "anonymous",
     GET: get,
 });

--- a/backend/src/functions/v3/getConsumption/index.ts
+++ b/backend/src/functions/v3/getConsumption/index.ts
@@ -22,6 +22,5 @@ appRequestMandatory(post);
 export const getConsumption = createEndpoint({
     moniker: "v3-getConsumption",
     route: "v3/getConsumption/{appId}",
-    authLevel: "anonymous",
     POST: post,
 });

--- a/backend/src/functions/v3/getNext/index.ts
+++ b/backend/src/functions/v3/getNext/index.ts
@@ -181,6 +181,5 @@ withPermissionCheck(post);
 export const getNext = createEndpoint({
     moniker: "v3-getNext",
     route: "v3/getNext/{appId}",
-    authLevel: "anonymous",
     POST: post,
 });

--- a/backend/src/functions/v3/storeAssignment/index.ts
+++ b/backend/src/functions/v3/storeAssignment/index.ts
@@ -128,7 +128,6 @@ appRequestOptional(postDelete);
 export const storeAssignment = createEndpoint({
     moniker: "v3-storeAssignment",
     route: "v3/storeAssignment/{appId}/{type}/{id}",
-    authLevel: "anonymous",
     POST: post,
 });
 
@@ -136,6 +135,5 @@ export const storeAssignment = createEndpoint({
 export const storeAssignmentDelete = createEndpoint({
     moniker: "v3-storeAssignment-delete",
     route: "v3/storeAssignment/{appId}/{type}/{id}/delete",
-    authLevel: "anonymous",
     POST: postDelete,
 });

--- a/backend/src/functions/v3/syncIds/index.ts
+++ b/backend/src/functions/v3/syncIds/index.ts
@@ -62,7 +62,6 @@ withPermissionCheck(handler);
 export const syncIds = createEndpoint({
     moniker: "v3-syncIds",
     route: "v3/syncIds/{appId}",
-    authLevel: "anonymous",
     POST: handler,
     PATCH: handler,
 });

--- a/backend/src/functions/v3/touch/index.ts
+++ b/backend/src/functions/v3/touch/index.ts
@@ -43,6 +43,5 @@ const post: AzureHttpHandler<TouchRequest, void> = async (req) => {
 export const touch = createEndpoint({
     moniker: "v3-touch",
     route: "v3/touch",
-    authLevel: "anonymous",
     POST: post
 });

--- a/backend/src/http/createEndpoint.ts
+++ b/backend/src/http/createEndpoint.ts
@@ -1,6 +1,7 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext, HttpMethod } from "@azure/functions";
 import { handleRequest } from "./handleRequest";
 import { AzureHttpHandler } from "./AzureHttpHandler";
+import { getHttpAuthLevel } from "../utils/httpAuthLevel";
 
 interface EndpointSetup {
     moniker: string;
@@ -50,6 +51,8 @@ export function createEndpoint(setup: EndpointSetup): void {
 
     if (authLevel) {
         options.authLevel = authLevel;
+    } else {
+        options.authLevel = getHttpAuthLevel();
     }
 
     app.http(moniker, options);

--- a/backend/src/utils/httpAuthLevel.ts
+++ b/backend/src/utils/httpAuthLevel.ts
@@ -1,0 +1,12 @@
+/**
+ * Determines the HTTP authentication level based on the environment variable.
+ * 
+ * @returns {string} The authentication level: 'function' or 'anonymous'
+ */
+export function getHttpAuthLevel(): string {
+    const value = process.env.USE_FUNCTION_ACCESS_KEYS;
+    if (!value) {
+        return "anonymous";
+    }
+    return value.toLowerCase() === "true" ? "function" : "anonymous";
+}

--- a/backend/test/functions/v3/authorizeApp.test.ts
+++ b/backend/test/functions/v3/authorizeApp.test.ts
@@ -74,8 +74,8 @@ describe("authorizeApp", () => {
             expect(endpointConfig.route).toBe("v3/authorizeApp/{appId}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register GET, POST, and DELETE handlers", () => {

--- a/backend/test/functions/v3/autoSyncIds.test.ts
+++ b/backend/test/functions/v3/autoSyncIds.test.ts
@@ -77,8 +77,8 @@ describe("autoSyncIds", () => {
             expect(endpointConfig.route).toBe("v3/autoSyncIds");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register POST and PATCH handlers", () => {

--- a/backend/test/functions/v3/check.test.ts
+++ b/backend/test/functions/v3/check.test.ts
@@ -56,8 +56,8 @@ describe("check", () => {
             expect(endpointConfig.route).toBe("v3/check");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register POST handler", () => {

--- a/backend/test/functions/v3/checkApp.test.ts
+++ b/backend/test/functions/v3/checkApp.test.ts
@@ -55,8 +55,8 @@ describe("checkApp", () => {
             expect(endpointConfig.route).toBe("v3/checkApp/{appId}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register only GET handler", () => {

--- a/backend/test/functions/v3/getConsumption.test.ts
+++ b/backend/test/functions/v3/getConsumption.test.ts
@@ -59,8 +59,8 @@ describe("getConsumption", () => {
             expect(endpointConfig.route).toBe("v3/getConsumption/{appId}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register only POST handler", () => {

--- a/backend/test/functions/v3/getNext.test.ts
+++ b/backend/test/functions/v3/getNext.test.ts
@@ -79,8 +79,8 @@ describe("getNext", () => {
             expect(endpointConfig.route).toBe("v3/getNext/{appId}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register only POST handler", () => {

--- a/backend/test/functions/v3/storeAssignment.test.ts
+++ b/backend/test/functions/v3/storeAssignment.test.ts
@@ -76,8 +76,8 @@ describe("storeAssignment", () => {
             expect(storeAssignmentConfig.route).toBe("v3/storeAssignment/{appId}/{type}/{id}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(storeAssignmentConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(storeAssignmentConfig.authLevel).toBeUndefined();
         });
 
         it("should register only POST handler", () => {
@@ -100,8 +100,8 @@ describe("storeAssignment", () => {
             expect(storeAssignmentDeleteConfig.route).toBe("v3/storeAssignment/{appId}/{type}/{id}/delete");
         });
 
-        it("should create delete endpoint with anonymous auth level", () => {
-            expect(storeAssignmentDeleteConfig.authLevel).toBe("anonymous");
+        it("should create delete endpoint with undefined auth level", () => {
+            expect(storeAssignmentDeleteConfig.authLevel).toBeUndefined();
         });
 
         it("should register only POST handler for delete endpoint", () => {

--- a/backend/test/functions/v3/syncIds.test.ts
+++ b/backend/test/functions/v3/syncIds.test.ts
@@ -71,8 +71,8 @@ describe("syncIds", () => {
             expect(endpointConfig.route).toBe("v3/syncIds/{appId}");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register POST and PATCH handlers", () => {

--- a/backend/test/functions/v3/touch.test.ts
+++ b/backend/test/functions/v3/touch.test.ts
@@ -43,8 +43,8 @@ describe("touch", () => {
             expect(endpointConfig.route).toBe("v3/touch");
         });
 
-        it("should create endpoint with anonymous auth level", () => {
-            expect(endpointConfig.authLevel).toBe("anonymous");
+        it("should create endpoint with undefined auth level", () => {
+            expect(endpointConfig.authLevel).toBeUndefined();
         });
 
         it("should register POST handler", () => {

--- a/backend/test/http/createEndpoint.test.ts
+++ b/backend/test/http/createEndpoint.test.ts
@@ -68,19 +68,6 @@ describe("createEndpoint", () => {
             );
         });
 
-        it("should not set authLevel when not provided", () => {
-            const getHandler: AzureHttpHandler = jest.fn();
-
-            createEndpoint({
-                moniker: "publicEndpoint",
-                route: "api/public",
-                GET: getHandler,
-            });
-
-            const callArgs = mockAppHttp.mock.calls[0][1];
-            expect(callArgs).not.toHaveProperty("authLevel");
-        });
-
         it("should support anonymous authLevel", () => {
             const getHandler: AzureHttpHandler = jest.fn();
 

--- a/backend/test/utils/httpAuthLevel.test.ts
+++ b/backend/test/utils/httpAuthLevel.test.ts
@@ -1,0 +1,92 @@
+import { getHttpAuthLevel } from "../../src/utils/httpAuthLevel";
+
+describe("getHttpAuthLevel", () => {
+    const originalEnv = process.env.USE_FUNCTION_ACCESS_KEYS;
+
+    afterEach(() => {
+        // Restore original environment variable after each test
+        if (originalEnv === undefined) {
+            delete process.env.USE_FUNCTION_ACCESS_KEYS;
+        } else {
+            process.env.USE_FUNCTION_ACCESS_KEYS = originalEnv;
+        }
+    });
+
+    describe("when USE_FUNCTION_ACCESS_KEYS is set to 'true'", () => {
+        it("should return 'function' for lowercase 'true'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "true";
+            expect(getHttpAuthLevel()).toBe("function");
+        });
+
+        it("should return 'function' for uppercase 'TRUE'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "TRUE";
+            expect(getHttpAuthLevel()).toBe("function");
+        });
+
+        it("should return 'function' for mixed case 'True'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "True";
+            expect(getHttpAuthLevel()).toBe("function");
+        });
+
+        it("should return 'function' for mixed case 'TrUe'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "TrUe";
+            expect(getHttpAuthLevel()).toBe("function");
+        });
+    });
+
+    describe("when USE_FUNCTION_ACCESS_KEYS is set to other values", () => {
+        it("should return 'anonymous' for 'false'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "false";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should return 'anonymous' for '1'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "1";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should return 'anonymous' for 'yes'", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "yes";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should return 'anonymous' for empty string", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should return 'anonymous' for 'true ' (with trailing space)", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "true ";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should return 'anonymous' for ' true' (with leading space)", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = " true";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+    });
+
+    describe("when USE_FUNCTION_ACCESS_KEYS is not set", () => {
+        it("should return 'anonymous' when environment variable is undefined", () => {
+            delete process.env.USE_FUNCTION_ACCESS_KEYS;
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle null-like values gracefully", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "null";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should handle numeric strings", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "0";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+
+        it("should handle special characters", () => {
+            process.env.USE_FUNCTION_ACCESS_KEYS = "true!";
+            expect(getHttpAuthLevel()).toBe("anonymous");
+        });
+    });
+});

--- a/doc/DeployingBackEnd.md
+++ b/doc/DeployingBackEnd.md
@@ -55,9 +55,10 @@ Your choice of operating system is entirely up to you. The app can run on Window
 
 The back-end requires the following environment variables to be configured.
 
-| Variable          | Value  | Usage notes                   |
-| ----------------- | ------ | ----------------------------- |
-| `PRIVATE_BACKEND` | `true` | Case-insensitive feature flag |
+| Variable                   | Value  | Usage notes                   |
+| -------------------------- | ------ | ----------------------------- |
+| `PRIVATE_BACKEND`          | `true` | Case-insensitive feature flag |
+| `USE_FUNCTION_ACCESS_KEYS` | `true` | Case-insensitive feature flag |
 
 #### `PRIVATE_BACKEND` Flag
 
@@ -68,6 +69,18 @@ When running the back-end on your own infrastructure, you must set this flag to 
 - User authorization checks (whether users are allowed to assign numbers)
 - Consumption counting
 - Orphan app management
+
+#### `USE_FUNCTION_ACCESS_KEYS` Flag
+
+This flag controls whether the back-end requires Azure Function access keys for authorization.
+
+**Default behavior (flag not set or `false`)**: All HTTP requests to function endpoints are accepted without authentication. Anyone who knows your Function App URL can access the back-end.
+
+**When set to `true`**: The back-end enforces authorization using Azure Function access keys:
+- **Obtaining the key**: In the Azure portal, navigate to your Function App → Functions → App keys. Copy the default host key or create a new one. 
+- **Configuring VS Code AL Ninja Extension**: Set the `objectIdNinja.backEndAPIKey` setting to the function access key you copied.
+- **Security**: All requests without a valid function access key will be rejected with HTTP 401 Unauthorized.
+
 
 ## Storage
 


### PR DESCRIPTION
This pull request refactors how HTTP authorization levels are set for v3 API endpoints in the backend. Instead of hardcoding `authLevel: "anonymous"` in each endpoint, the authentication level is now determined dynamically at runtime based on an environment variable. This makes it easier to switch between `anonymous` and `function` authorization for all endpoints without changing the code. Corresponding tests have been updated to reflect this new behavior.

Key changes:

**Dynamic authorization level for endpoints**
* Removed the hardcoded `authLevel: "anonymous"` property from all v3 endpoint definitions, allowing for environment-based configuration instead.

**Infrastructure and utility updates**
* Updated `createEndpoint` in `createEndpoint.ts` to use a new utility function, `getHttpAuthLevel`, which reads the `USE_FUNCTION_ACCESS_KEYS` environment variable to determine the auth level (`function` or `anonymous`).

**Test updates**
* Modified all affected endpoint tests to expect `authLevel` to be `undefined` (since it is now set at runtime), instead of `"anonymous"`.